### PR TITLE
PMNGIOS-978 [platform] Update to opencv 4.6.0

### DIFF
--- a/CardIO.xcodeproj/project.pbxproj
+++ b/CardIO.xcodeproj/project.pbxproj
@@ -7,53 +7,45 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C9E044DAEB6C7F62F0FFA86D /* Pods_Dummy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BD3EA67F91D0789F7D36515 /* Pods_Dummy.framework */; };
+		D725BDF47FD4AAD1BD8105EB /* Pods_Dummy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2F7173C6C184564450E37144 /* Pods_Dummy.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1111F2AE3243016C3050AB69 /* Pods-Dummy.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dummy.release.xcconfig"; path = "Target Support Files/Pods-Dummy/Pods-Dummy.release.xcconfig"; sourceTree = "<group>"; };
+		2F7173C6C184564450E37144 /* Pods_Dummy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Dummy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AF384D3F61C020442398E70 /* Dummy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Dummy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4D3245E16E3CF95FD0E30C0E /* Pods-Dummy.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dummy.release.xcconfig"; path = "Target Support Files/Pods-Dummy/Pods-Dummy.release.xcconfig"; sourceTree = "<group>"; };
-		7BD3EA67F91D0789F7D36515 /* Pods_Dummy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Dummy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F6744DC329AEBCEE993EC00C /* Pods-Dummy.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dummy.debug.xcconfig"; path = "Target Support Files/Pods-Dummy/Pods-Dummy.debug.xcconfig"; sourceTree = "<group>"; };
+		91051BAC19C1F5FDE2647C18 /* Pods-Dummy.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Dummy.debug.xcconfig"; path = "Target Support Files/Pods-Dummy/Pods-Dummy.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		EE8015CBC20C969F2E09C729 /* Frameworks */ = {
+		96CF1E5D9379A68313A32150 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9E044DAEB6C7F62F0FFA86D /* Pods_Dummy.framework in Frameworks */,
+				D725BDF47FD4AAD1BD8105EB /* Pods_Dummy.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		042627A1411553EB3D087629 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				91051BAC19C1F5FDE2647C18 /* Pods-Dummy.debug.xcconfig */,
+				1111F2AE3243016C3050AB69 /* Pods-Dummy.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		1B40E9868AF0882CFA68988C = {
 			isa = PBXGroup;
 			children = (
 				63E66F4141E92C3B5DF6677E /* Products */,
-				4B2F5604B1984E615F07DDD5 /* Pods */,
-				48BEBF1BAB466FA9CE018C86 /* Frameworks */,
+				042627A1411553EB3D087629 /* Pods */,
+				D2ABF8B2F1B4B4DD4CF31DD4 /* Frameworks */,
 			);
-			sourceTree = "<group>";
-		};
-		48BEBF1BAB466FA9CE018C86 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				7BD3EA67F91D0789F7D36515 /* Pods_Dummy.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		4B2F5604B1984E615F07DDD5 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				F6744DC329AEBCEE993EC00C /* Pods-Dummy.debug.xcconfig */,
-				4D3245E16E3CF95FD0E30C0E /* Pods-Dummy.release.xcconfig */,
-			);
-			name = Pods;
-			path = Pods;
 			sourceTree = "<group>";
 		};
 		63E66F4141E92C3B5DF6677E /* Products */ = {
@@ -64,6 +56,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		D2ABF8B2F1B4B4DD4CF31DD4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				2F7173C6C184564450E37144 /* Pods_Dummy.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -71,9 +71,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 375841A1E3B77B073DA956E7 /* Build configuration list for PBXNativeTarget "Dummy" */;
 			buildPhases = (
-				ADD17A82F1374648B1BD4A76 /* [CP] Check Pods Manifest.lock */,
+				D83CDABFCE0ABD19F01B1704 /* [CP] Check Pods Manifest.lock */,
 				0935E0A3D61CD6AD26B89E74 /* Sources */,
-				EE8015CBC20C969F2E09C729 /* Frameworks */,
+				96CF1E5D9379A68313A32150 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -95,7 +95,7 @@
 				};
 			};
 			buildConfigurationList = 759C217CD52F7868DB426BBA /* Build configuration list for PBXProject "CardIO" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -113,7 +113,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		ADD17A82F1374648B1BD4A76 /* [CP] Check Pods Manifest.lock */ = {
+		D83CDABFCE0ABD19F01B1704 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -212,7 +212,7 @@
 		};
 		620E78090596529829640C45 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F6744DC329AEBCEE993EC00C /* Pods-Dummy.debug.xcconfig */;
+			baseConfigurationReference = 91051BAC19C1F5FDE2647C18 /* Pods-Dummy.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;
@@ -236,7 +236,7 @@
 		};
 		6A68D1D3BD1F4D29166A86BE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4D3245E16E3CF95FD0E30C0E /* Pods-Dummy.release.xcconfig */;
+			baseConfigurationReference = 1111F2AE3243016C3050AB69 /* Pods-Dummy.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CURRENT_PROJECT_VERSION = 1;

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-binary "https://raw.githubusercontent.com/revolut-mobile/opencv-binary/master/opencv2.json" "4.5.2"
+binary "https://raw.githubusercontent.com/revolut-mobile/opencv-binary/master/opencv2.json" "4.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,10 +84,11 @@ GEM
       nanaimo (~> 0.3.0)
 
 PLATFORMS
+  arm64-darwin-21
   universal-darwin-19
 
 DEPENDENCIES
   cocoapods (= 1.10.1)
 
 BUNDLED WITH
-   2.2.3
+   2.3.5

--- a/Pods/Target Support Files/OpenCV/OpenCV-xcframeworks.sh
+++ b/Pods/Target Support Files/OpenCV/OpenCV-xcframeworks.sh
@@ -149,5 +149,5 @@ install_xcframework() {
   echo "Copied $source to $destination"
 }
 
-install_xcframework "${PODS_ROOT}/../Carthage/Build/opencv2.xcframework" "opencv2" "framework" "ios-arm64_armv7" "ios-arm64_x86_64-simulator"
+install_xcframework "${PODS_ROOT}/../Carthage/Build/opencv2.xcframework" "opencv2" "framework" "ios-arm64_x86_64-simulator" "ios-arm64"
 


### PR DESCRIPTION
IN THIS PR:
* Update to opencv 4.6.0

Context: the removal of the armv7 architecture requires the update of the xcode project that is hosted inside this repo and is used by carthage to build the CardIO binary